### PR TITLE
Bundle Price Calculator Classes

### DIFF
--- a/Pricing/Bundle/Adjustment/Calculator.php
+++ b/Pricing/Bundle/Adjustment/Calculator.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Findify\Findify\Pricing\Bundle\Adjustment;
+
+use Magento\Framework\Pricing\Adjustment\Calculator as CalculatorBase;
+use Magento\Framework\Pricing\Amount\AmountFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Tax\Helper\Data as TaxHelper;
+
+/**
+ * Bundle price calculator
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class Calculator extends \Magento\Bundle\Pricing\Adjustment\Calculator
+{
+
+    protected $selectionListIds;
+
+    public function __construct(
+    CalculatorBase $calculator,
+        AmountFactory $amountFactory,
+        \Findify\Findify\Pricing\Bundle\Price\BundleSelectionFactory $bundleSelectionFactory,
+        TaxHelper $taxHelper,
+        PriceCurrencyInterface $priceCurrency 
+        
+    ) {
+
+        $this->calculator = $calculator;
+        $this->amountFactory = $amountFactory;
+        $this->selectionFactory = $bundleSelectionFactory;
+        $this->taxHelper = $taxHelper;
+        $this->priceCurrency = $priceCurrency;
+    }
+
+    protected function getSelectionAmounts(\Magento\Catalog\Model\Product $bundleProduct,
+        $searchMin,
+        $useRegularPrice = false) {
+        // Flag shows - is it necessary to find minimal option amount in case if all options are not required
+        $shouldFindMinOption = false;
+        if ($searchMin && $bundleProduct->getPriceType() == \Magento\Bundle\Model\Product\Price::PRICE_TYPE_DYNAMIC && !$this->hasRequiredOption($bundleProduct)
+        ) {
+            $shouldFindMinOption = true;
+        }
+
+        $canSkipRequiredOptions = $searchMin && !$shouldFindMinOption;
+
+        $currentPrice = false;
+        $priceList = [];
+        foreach ($this->getBundleOptions($bundleProduct) as $option) {
+            if ($this->canSkipOption($option, $canSkipRequiredOptions)) {
+                continue;
+            }
+            $selectionPriceList = $this->createSelectionPriceList($option, $bundleProduct, $useRegularPrice);
+            $selectionPriceList = $this->processOptions($option, $selectionPriceList, $searchMin);
+
+            $lastSelectionPrice = end($selectionPriceList);
+            $lastValue = $lastSelectionPrice->getAmount()->getValue() * $lastSelectionPrice->getQuantity();
+            if ($shouldFindMinOption && (!$currentPrice ||
+                $lastValue < ($currentPrice->getAmount()->getValue() * $currentPrice->getQuantity()))
+            ) {
+                $currentPrice = end($selectionPriceList);
+            } elseif (!$shouldFindMinOption) {
+                $priceList = array_merge($priceList, $selectionPriceList);
+            }
+        }
+
+        $this->selectionListIds = [];
+        foreach ($priceList as $selectionPrice) {
+            $this->selectionListIds[] = $selectionPrice->getSelection()->getId();
+        }
+
+        return $shouldFindMinOption ? [$currentPrice] : $priceList;
+    }
+
+    public function getSelectionIds() {
+        return $this->selectionListIds;
+    }
+
+
+}

--- a/Pricing/Bundle/Price/BundleSelectionFactory.php
+++ b/Pricing/Bundle/Price/BundleSelectionFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Findify\Findify\Pricing\Bundle\Price;
+
+use Magento\Catalog\Model\Product;
+
+/**
+ * Bundle selection price factory
+ * @api
+ * @since 100.0.2
+ */
+class BundleSelectionFactory extends \Magento\Bundle\Pricing\Price\BundleSelectionFactory
+{
+    /**
+     * Default selection class
+     */
+    const SELECTION_CLASS_DEFAULT = \Findify\Findify\Pricing\Bundle\Price\BundleSelectionPrice::class;
+
+    /**
+     * Create Price object for particular product
+     *
+     * @param Product $bundleProduct
+     * @param Product $selection
+     * @param float $quantity
+     * @param array $arguments
+     * @return BundleSelectionPrice
+     */
+    public function create(
+        Product $bundleProduct,
+        Product $selection,
+        $quantity,
+        array $arguments = []
+    ) {
+        $arguments['bundleProduct'] = $bundleProduct;
+        $arguments['saleableItem'] = $selection;
+        $arguments['quantity'] = $quantity ? floatval($quantity) : 1.;
+
+        return $this->objectManager->create(self::SELECTION_CLASS_DEFAULT, $arguments);
+    }
+}

--- a/Pricing/Bundle/Price/BundleSelectionPrice.php
+++ b/Pricing/Bundle/Price/BundleSelectionPrice.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Findify\Findify\Pricing\Bundle\Price;
+
+/**
+ * Bundle option price
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @api
+ * @since 100.0.2
+ */
+class BundleSelectionPrice extends \Magento\Bundle\Pricing\Price\BundleSelectionPrice
+{
+
+    public function getSelection(){
+        return $this->selection;
+    }
+    
+}


### PR DESCRIPTION
Extend Magento-Bundle Pricing modules to store selection ID (child product) values for use in the feed.