### PR TITLE
Configuration for parent title on the child level

### DIFF
--- a/Model/Fields/MandatoryFields.php
+++ b/Model/Fields/MandatoryFields.php
@@ -26,6 +26,7 @@ class MandatoryFields implements FieldsInterface
      */
     const ID = 'id';
     const TITLE = 'title';
+    const VARIANT_TITLE = 'variant_title';
     const DESCRIPTION = 'description';
     const PRICE = 'price';
     const IMAGE_URL = 'image_url';
@@ -120,6 +121,9 @@ class MandatoryFields implements FieldsInterface
 
         if ($parent !== null) {
             $productData[self::ITEM_GROUP_ID] = $parent->getId();
+            
+            $productData[self::VARIANT_TITLE] = $productData[self::TITLE];
+            $productData[self::TITLE] = $parent->getName();
 
             if ($this->scopeConfig->getValue(self::USE_PARENT_IMAGE_CONFIG_PATH, 'store', $store)) {
                 $productData[self::IMAGE_URL] = $this->getImageUrl($parent, $store, 'image');

--- a/Model/Fields/MandatoryFields.php
+++ b/Model/Fields/MandatoryFields.php
@@ -21,6 +21,7 @@ class MandatoryFields implements FieldsInterface
     const USE_PARENT_IMAGE_CONFIG_PATH = 'findify_configuration/general/parent_image';
     const USE_PARENT_URL_CONFIG_PATH = 'findify_configuration/general/parent_url';
     const USE_CACHE_IMAGE_CONFIG_PATH = 'findify_configuration/general/cache_image';
+    const USE_PARENT_TITLE_ON_CHILDREN = 'findify_configuration/general/parent_title';
     /**#@+
      * Mandatory Fields
      */
@@ -121,9 +122,11 @@ class MandatoryFields implements FieldsInterface
 
         if ($parent !== null) {
             $productData[self::ITEM_GROUP_ID] = $parent->getId();
-            
-            $productData[self::VARIANT_TITLE] = $productData[self::TITLE];
-            $productData[self::TITLE] = $parent->getName();
+
+            if ($this->scopeConfig->getValue(self::USE_PARENT_TITLE_ON_CHILDREN, 'store', $store)) {
+                $productData[self::VARIANT_TITLE] = $productData[self::TITLE];
+                $productData[self::TITLE] = $parent->getName();
+            }
 
             if ($this->scopeConfig->getValue(self::USE_PARENT_IMAGE_CONFIG_PATH, 'store', $store)) {
                 $productData[self::IMAGE_URL] = $this->getImageUrl($parent, $store, 'image');

--- a/README.md
+++ b/README.md
@@ -112,13 +112,16 @@ By default any Not Visible Individually product is excluded from the feed. You m
 There might be a case when product configurable price is different than their child prices.
 Findify uses `item_group_id` field for grouping variants with their parent product. In a search page, it shows a combined result, which consists of the price range of all products with the same `item_group_id`, both configurable product and its children.
 It may cause a confusion in a product price. Removing the configurable product from the feed will fix the issue, let the price be combined only from children products.
-By default, **Remove parent products from appearing in the search** is turn **On** 
+By default, **Remove parent products from appearing in the search** is turned **On** 
 
 There might be cases when Product URLs for Findify Variants should be pulled from their parent product. In general, simple child products are not single visible, thus their Product URL is not working and useless.
-By default, **Use Parent URLs for Findify variants** is turn **On** 
+By default, **Use Parent URLs for Findify variants** is turned **On** 
  
 The same thing relates to variants' images. A configurable product might have its own images, while child product might not have ones.
-By default, **Use Parent Images for Findify variants** is turn **On** 
+By default, **Use Parent Images for Findify variants** is turned **On** 
+
+Usually you want to show parent titles in the search results, but still have child title searchale. If you want to show child titles in the search results, you will need to disable this setting.
+By default **Use Parent Titles for Findify variants** is turned **On**
 
 ![specific_settings](doc/specific_settings.png)
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -62,6 +62,10 @@
                     <label>Remove parent products from appearing in the search</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="parent_title" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Use Parent Titles for Findify variants</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="parent_url" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use Parent URLs for Findify variants</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -6,6 +6,7 @@
             <general>
                 <remove>1</remove>
                 <parent_url>1</parent_url>
+                <parent_title>1</parent_title>
                 <parent_image>1</parent_image>
                 <enable_optional>1</enable_optional>
                 <exclude_product_visibility>1</exclude_product_visibility>


### PR DESCRIPTION
This will enable a new option and allow to keep the parent title on the variant level, so that in the search the parent title is shown. The variant title should also be kept in the feed in the `variant_title` field, so that search by variant title is still applied.